### PR TITLE
Set span error bool on after callback

### DIFF
--- a/otgorm.go
+++ b/otgorm.go
@@ -75,6 +75,7 @@ func (c *callbacks) after(scope *gorm.Scope, operation string) {
 	if operation == "" {
 		operation = strings.ToUpper(strings.Split(scope.SQL, " ")[0])
 	}
+	ext.Error.Set(sp, scope.HasError())
 	ext.DBStatement.Set(sp, scope.SQL)
 	sp.SetTag("db.table", scope.TableName())
 	sp.SetTag("db.method", operation)

--- a/otgorm_test.go
+++ b/otgorm_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/smacker/opentracing-gorm"
 )
@@ -58,11 +58,14 @@ func TestPool(t *testing.T) {
 		t.Errorf("first span operation should be sql but it's '%s'", sqlSpan.OperationName)
 	}
 
-	expectedTags := map[string]string{
+	expectedTags := map[string]interface{}{
+		"error":        false,
 		"db.table":     "products",
 		"db.method":    "SELECT",
 		"db.type":      "sql",
 		"db.statement": `SELECT * FROM "products"  WHERE "products"."deleted_at" IS NULL AND (("products"."id" = 1)) ORDER BY "products"."id" ASC LIMIT 1`,
+		"db.err":       false,
+		"db.count":     int64(1),
 	}
 
 	sqlTags := sqlSpan.Tags()


### PR DESCRIPTION
Some APM providers (like Datadog) require the span error tag to be set in order to properly display the status of the trace.
This PR will set this flag with the result of `scope.HasError()` hence making the status properly display error cases.

![image](https://user-images.githubusercontent.com/1855079/49593344-4046d180-f96b-11e8-9277-6ce2033b058c.png)

Also, a test case was failing which is also fixed here.