### PR TITLE
Add SQL var to tag `db.vars`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/smacker/opentracing-gorm
+
+go 1.14

--- a/otgorm.go
+++ b/otgorm.go
@@ -2,6 +2,7 @@ package otgorm
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -77,10 +78,15 @@ func (c *callbacks) after(scope *gorm.Scope, operation string) {
 	}
 	ext.Error.Set(sp, scope.HasError())
 	ext.DBStatement.Set(sp, scope.SQL)
+
 	sp.SetTag("db.table", scope.TableName())
 	sp.SetTag("db.method", operation)
 	sp.SetTag("db.err", scope.HasError())
 	sp.SetTag("db.count", scope.DB().RowsAffected)
+
+	b, _ := json.Marshal(scope.SQLVars)
+	sp.SetTag("db.vars", string(b))
+
 	sp.Finish()
 }
 


### PR DESCRIPTION
Beside statement, I add SQL vars to opentracing `db.vars` tag.

The result like this image:

![image](https://user-images.githubusercontent.com/25898298/90498034-0420c800-e172-11ea-9a03-4afa2fafd49f.png)
